### PR TITLE
Always add MIR_MESA_KMS_DISABLE_MODESET_PROBE to env-hacks

### DIFF
--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -12,10 +12,16 @@ vt=4
 console-provider=vt
 wallpaper-font=$(dirname ${SNAP})/current/usr/share/fonts/truetype/freefont/FreeSansBold.ttf
 EOT
-  # Hack to workaround issue #704
-  if [[ $(uname -r) =~ ^.*raspi2$ ]]; then
-    echo env-hacks=MIR_MESA_KMS_DISABLE_MODESET_PROBE >> "${mir_demo_server_config}"
-  fi
+fi
+
+# As mir-kiosk HAS to run mesa-kms we can safely override the probe for KMS everywhere.
+# This ensures the best possible diagnostics whenever we fail to start.
+env_hacks=$(sed -n 's/^env-hacks=\(.*\)$/\1/p' ${miral_kiosk_config})
+if [[ ! ${env_hacks} =~ .*MIR_MESA_KMS_DISABLE_MODESET_PROBE* ]]
+then
+  sed --in-place '/^env-hacks=/d' ${miral_kiosk_config}
+  env_hacks=env-hacks=${env_hacks}:MIR_MESA_KMS_DISABLE_MODESET_PROBE
+  echo ${env_hacks/=:/=} >> "${miral_kiosk_config}"
   let config_changes+=1
 fi
 


### PR DESCRIPTION
Always add MIR_MESA_KMS_DISABLE_MODESET_PROBE to env-hacks.

As mir-kiosk currently HAS to run mesa-kms we can safely override the probe for KMS everywhere. This ensures the best possible diagnostics whenever we fail to start. C.f. https://discourse.ubuntu.com/t/failed-to-find-platform-for-current-system-when-starting-mir-kiosk/10124