### PR TITLE
Add mir-graphics-drivers-nvidia (and related stuff)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -112,7 +112,8 @@ parts:
     plugin: nil
     override-pull: |
       sudo apt --assume-yes install software-properties-common
-      sudo add-apt-repository -yu ppa:mir-team/release
+      sudo add-apt-repository ppa:graphics-drivers/ppa
+      sudo add-apt-repository -yu ppa:mir-team/dev
       snapcraftctl pull
 
   recipe-version:
@@ -136,6 +137,8 @@ parts:
     stage-packages:
     - fonts-freefont-ttf
     - mir-graphics-drivers-desktop
+    - mir-graphics-drivers-nvidia
+    - mir-platform-graphics-eglstream-kms16
     - mir-test-tools
     - glmark2-es2
     - glmark2-data


### PR DESCRIPTION
This has limited utility (the eglstream kernel drivers must exactly match the userspace drivers in the snap) but breaks nothing.