### PR TITLE
No need to "passthrough" the "layout"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -102,10 +102,9 @@ slots:
   mir:
   wayland:
 
-passthrough:
-  layout:
-    /usr/share:
-      bind: $SNAP/usr/share
+layout:
+  /usr/share:
+    bind: $SNAP/usr/share
 
 parts:
   ppa-mir:


### PR DESCRIPTION
No need to "passthrough" the "layout" (as LP has snapcraft 3.6)