### PR TITLE
Change the default VT to avoid conflict with mir-kiosk

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -9,4 +9,4 @@ if [ ! -d "$SNAP_DATA/.cache" ]; then
    mkdir   $SNAP_DATA/.cache
 fi
 
-snapctl set vt=4 console-provider=vt
+snapctl set vt=5 console-provider=vt


### PR DESCRIPTION
Change the default VT to avoid conflict with mir-kiosk.

If both mir-kiosk and mir-tests-tools are configured to use the same VT then only one can work. To avoid confusion, use different defaults.