### PR TITLE
Fix edge

### DIFF
--- a/performance/performance-env.sh
+++ b/performance/performance-env.sh
@@ -4,7 +4,25 @@ if [ $(id -u) == 0 ]; then
   export MIR_SERVER_CONSOLE_PROVIDER=$(snapctl get console-provider)
 fi
 # Hack to workaround issue #704
-if [[ $(uname -r) =~ ^.*raspi2$ ]]; then
+if [ $(uname -r) =~ ^.*raspi2$ ]; then
   export MIR_MESA_KMS_DISABLE_MODESET_PROBE=on
 fi
+
+# For X11 we need .X11-unix/ in the snap's /tmp directory
+mkdir -p /tmp/.X11-unix
+
+# We need to stop Mir conflicting with any existing X11 session.
+# Mir detects existing sessions my scanning /tmp/.X11-unix
+# but we don't have the real /tmp, but a snap specific one.
+# So fake the existing $DISPLAY in the fake /tmp/.X11-unix
+if [ -z "${DISPLAY}" ]
+then touch /tmp/.X11-unix/X${DISPLAY:1}
+fi
+# A few more for luck
+touch /tmp/.X11-unix/X0
+touch /tmp/.X11-unix/X1
+touch /tmp/.X11-unix/X2
+touch /tmp/.X11-unix/X3
+touch /tmp/.X11-unix/X4
+
 exec "$@"

--- a/performance/performance-env.sh
+++ b/performance/performance-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 if [ $(id -u) == 0 ]; then
   export MIR_SERVER_VT=$(snapctl get vt)
   export MIR_SERVER_CONSOLE_PROVIDER=$(snapctl get console-provider)
@@ -8,21 +8,30 @@ if [ $(uname -r) =~ ^.*raspi2$ ]; then
   export MIR_MESA_KMS_DISABLE_MODESET_PROBE=on
 fi
 
-# For X11 we need .X11-unix/ in the snap's /tmp directory
-mkdir -p /tmp/.X11-unix
+# Use libmiral3 as a proxy to test for fixes to Mir's X11 handling (in Mir 2.x)
+if [ -d $SNAP/usr/share/doc/libmiral3 ]; then
+  # With Mir 1.x:
+  #   Xwayland . . : fails to create an X11 socket inside the snap
+  #   ClientLatency: uses a console-services stub that conflicts with MIR_SERVER_CONSOLE_PROVIDER
+  export MIR_SERVER_ENABLE_MIRCLIENT="on"
+  exec "$@ --gtest_filter=-GLMark2Xwayland*:ClientLatency*"
+else
+  # For X11 we need .X11-unix/ in the snap's /tmp directory
+  mkdir -p /tmp/.X11-unix
 
-# We need to stop Mir conflicting with any existing X11 session.
-# Mir detects existing sessions my scanning /tmp/.X11-unix
-# but we don't have the real /tmp, but a snap specific one.
-# So fake the existing $DISPLAY in the fake /tmp/.X11-unix
-if [ -z "${DISPLAY}" ]
-then touch /tmp/.X11-unix/X${DISPLAY:1}
+  # We need to stop Mir conflicting with any existing X11 session.
+  # Mir detects existing sessions my scanning /tmp/.X11-unix
+  # but we don't have the real /tmp, but a snap specific one.
+  # So fake the existing $DISPLAY in the fake /tmp/.X11-unix
+  if [ -z "${DISPLAY}" ]
+  then touch /tmp/.X11-unix/X${DISPLAY:1}
+  fi
+  # A few more for luck
+  touch /tmp/.X11-unix/X0
+  touch /tmp/.X11-unix/X1
+  touch /tmp/.X11-unix/X2
+  touch /tmp/.X11-unix/X3
+  touch /tmp/.X11-unix/X4
+
+  exec "$@"
 fi
-# A few more for luck
-touch /tmp/.X11-unix/X0
-touch /tmp/.X11-unix/X1
-touch /tmp/.X11-unix/X2
-touch /tmp/.X11-unix/X3
-touch /tmp/.X11-unix/X4
-
-exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,6 +57,12 @@ apps:
     environment:
       MIR_SERVER_ENABLE_MIRCLIENT: "on"
 
+  # Version of performance tests to work with Mir master (and 2.x)
+  post-mir-1-performance-test:
+    command: performance-env.sh wrapper mir_performance_tests
+    plugs:
+      - network-bind
+
   # I don't know why, but having this here makes things work
   dummy:
     command: ls
@@ -102,6 +108,8 @@ slots:
 layout:
   /usr/share:
     bind: $SNAP/usr/share
+  /usr/bin/Xwayland:
+    symlink: $SNAP/usr/bin/Xwayland
 
 parts:
   recipe-version:
@@ -116,7 +124,7 @@ parts:
   mir-test-tools:
     after: [recipe-version]
     plugin: ppa
-    ppa: [mir-team/rc, graphics-drivers/ppa]
+    ppa: [mir-team/dev, graphics-drivers/ppa]
     override-pull: |
       snapcraftctl pull
       mir_version=`LANG=C apt-cache policy mir-test-tools | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
@@ -198,3 +206,9 @@ parts:
     source: wrapper
     organize:
       wrapper: bin/wrapper
+
+  xwayland:
+    plugin: nil
+    stage-packages:
+      - xwayland
+      - libbz2-1.0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -51,14 +51,6 @@ apps:
       PATH: $SNAP/bin/:$SNAP/usr/bin/:${SNAP}/usr/games:${PATH}
 
   performance-test:
-    # Xwayland . . : fails to create an X11 socket inside the snap
-    # ClientLatency: uses a console-services stub that conflicts with MIR_SERVER_CONSOLE_PROVIDER
-    command: performance-env.sh wrapper mir_performance_tests --gtest_filter=-GLMark2Xwayland*:ClientLatency*
-    environment:
-      MIR_SERVER_ENABLE_MIRCLIENT: "on"
-
-  # Version of performance tests to work with Mir master (and 2.x)
-  post-mir-1-performance-test:
     command: performance-env.sh wrapper mir_performance_tests
     plugs:
       - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,18 +17,8 @@ environment:
   __EGL_VENDOR_LIBRARY_DIRS: $SNAP/etc/glvnd/egl_vendor.d:$SNAP/usr/share/glvnd/egl_vendor.d
 
 apps:
-  basic-test:
-    command: wrapper mir_demo_server --test-client mir_demo_client_basic --test-timeout 1
-    environment:
-      MIR_SERVER_ENABLE_MIRCLIENT: "on"
-
   smoke-test:
     command: wrapper mir-smoke-test-runner
-
-  stress-test:
-    command: wrapper mir_demo_server --test-client mir_stress
-    environment:
-      MIR_SERVER_ENABLE_MIRCLIENT: "on"
 
   # SDL2 example
   sdl2-test:


### PR DESCRIPTION
Fix edge.

There are changes on Mir master that broke the edge channel:

  o There's no mir_demo_client_basic as used by the basic-test
  o There's no mir-stress as used by the stress-test

Drop these tests.

Also update the performance-test to run the X11 based tests with Mir 2.0