### PR TITLE
[wrapper] stage bash (Fixes MirServer/mir#1721)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -193,6 +193,7 @@ parts:
 
   wrapper:
     plugin: dump
+    stage-packages: [bash]
     source: wrapper
     organize:
       wrapper: bin/wrapper


### PR DESCRIPTION
The switch to core20 made this break since we didn't include our own bash.