### PR TITLE
Don't run the Xwayland tests when they can't succeed

### DIFF
--- a/performance/performance-env.sh
+++ b/performance/performance-env.sh
@@ -1,20 +1,7 @@
 #!/bin/bash
 
-# For X11 we need .X11-unix/ in the snap's /tmp directory
-mkdir -p /tmp/.X11-unix
-
-# We need to stop Mir conflicting with any existing X11 session.
-# Mir detects existing sessions my scanning /tmp/.X11-unix
-# but we don't have the real /tmp, but a snap specific one.
-# So fake the existing $DISPLAY in the fake /tmp/.X11-unix
-if [ -z "${DISPLAY}" ]
-then touch /tmp/.X11-unix/X${DISPLAY:1}
+if ! snapctl is-connected x11 || echo "$@" | grep --quiet "\-\-gtest_filter="; then
+  exec "$@"
+else
+  exec "$@" --gtest_filter=-GLMark2Xwayland.*
 fi
-# A few more for luck
-touch /tmp/.X11-unix/X0
-touch /tmp/.X11-unix/X1
-touch /tmp/.X11-unix/X2
-touch /tmp/.X11-unix/X3
-touch /tmp/.X11-unix/X4
-
-exec "$@"

--- a/performance/performance-env.sh
+++ b/performance/performance-env.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# For X11 we need .X11-unix/ in the snap's /tmp directory
+mkdir -p /tmp/.X11-unix
+
 if ! snapctl is-connected x11 || echo "$@" | grep --quiet "\-\-gtest_filter="; then
   exec "$@"
 else


### PR DESCRIPTION
snapd changed the X11 interface so that we can no longer connect to the host's abstract socket. (This was to make X11 based snaps work on GNOME, which was more important than our tests.)