### PR TITLE
performance: don't hide x11 tests

### DIFF
--- a/performance/performance-env.sh
+++ b/performance/performance-env.sh
@@ -3,8 +3,4 @@
 # For X11 we need .X11-unix/ in the snap's /tmp directory
 mkdir -p /tmp/.X11-unix
 
-if ! snapctl is-connected x11 || echo "$@" | grep --quiet -e "\-\-gtest_filter=" -e "/bin/bash"; then
-  exec "$@"
-else
-  exec "$@" --gtest_filter=-GLMark2Xwayland.*
-fi
+exec "$@"


### PR DESCRIPTION
Rather than hiding them, require the test environment to be right, or disable the tests.