### PR TITLE
Bundle mir_flutter_app into mir-test-tools snap

### DIFF
--- a/mir-flutter-app/mir_flutter_app.sh
+++ b/mir-flutter-app/mir_flutter_app.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+${SNAP}/bin/mir_flutter_app&
+pid=$!
+trap 'kill -s SIGTERM $pid && exit 0' SIGTERM
+wait $pid
+exit -1

--- a/mir-flutter-app/mir_flutter_app.sh
+++ b/mir-flutter-app/mir_flutter_app.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-${SNAP}/bin/mir_flutter_app&
+${SNAP}/mir_flutter_app&
 pid=$!
 trap 'kill -s SIGTERM $pid && exit 0' SIGTERM
 wait $pid

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -75,6 +75,14 @@ apps:
     environment:
       PATH: $SNAP/bin/:$SNAP/usr/bin/:${SNAP}/usr/games:${PATH}
 
+  # Reference application for Mir window semantics
+  mir-flutter-app:
+    command-chain:
+      - bin/server-wrapper
+      - bin/wrapper
+      - bin/graphics-core22-wrapper
+    command: usr/bin/mir_demo_server --test-client $SNAP/mir_flutter_app.sh --test-timeout 120
+
   performance-test:
     command-chain:
       - bin/performance-env.sh
@@ -201,6 +209,35 @@ parts:
       "/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" > "$CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache"
       sed s!$CRAFT_PRIME!!g --in-place "$CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 
+  mir-flutter-app:
+    plugin: nil
+    source: https://github.com/hbatagelo/mir_flutter_app.git
+    build-snaps:
+      - flutter/latest/stable
+    build-environment:
+      - C_INCLUDE_PATH: /snap/flutter/current/usr/include
+      - LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/snap/flutter/current/usr/lib/$CRAFT_ARCH_TRIPLET
+      - PKG_CONFIG_PATH: ${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}/snap/flutter/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig
+      - XDG_DATA_DIRS: /snap/flutter/current/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
+    override-build: |
+      set -eux
+      mkdir -p $CRAFT_PART_INSTALL/bin/lib
+      flutter channel stable
+      flutter upgrade
+      flutter config --enable-linux-desktop
+      flutter doctor
+      flutter pub get
+      flutter build linux --release -v
+      cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
+    stage-packages:
+      - fonts-ubuntu
+      - libgtk-3-0
+      - libgl1
+
+  mir-flutter-app-launcher:
+    plugin: dump
+    source: mir-flutter-app
+
   performance:
     plugin: dump
     source: performance
@@ -221,7 +258,7 @@ parts:
       - libbz2-1.0
 
   graphics-core22:
-    after: [mir-test-tools, icons, sdl2-apps, qmldemo, gtk3app, performance, wrapper, xwayland]
+    after: [mir-test-tools, icons, sdl2-apps, qmldemo, gtk3app, mir-flutter-app, performance, wrapper, xwayland]
     source: https://github.com/MirServer/graphics-core22.git
     plugin: dump
     override-prime: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -210,25 +210,10 @@ parts:
       sed s!$CRAFT_PRIME!!g --in-place "$CRAFT_PRIME/usr/lib/$CRAFT_ARCH_TRIPLET/gdk-pixbuf-2.0/2.10.0/loaders.cache"
 
   mir-flutter-app:
-    plugin: nil
+    plugin: flutter
+    flutter-target: lib/main.dart
     source: https://github.com/hbatagelo/mir_flutter_app.git
-    build-snaps:
-      - flutter/latest/stable
-    build-environment:
-      - C_INCLUDE_PATH: /snap/flutter/current/usr/include
-      - LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/snap/flutter/current/usr/lib/$CRAFT_ARCH_TRIPLET
-      - PKG_CONFIG_PATH: ${PKG_CONFIG_PATH:+$PKG_CONFIG_PATH:}/snap/flutter/current/usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig
-      - XDG_DATA_DIRS: /snap/flutter/current/usr/share${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
-    override-build: |
-      set -eux
-      mkdir -p $CRAFT_PART_INSTALL/bin/lib
-      flutter channel stable
-      flutter upgrade
-      flutter config --enable-linux-desktop
-      flutter doctor
-      flutter pub get
-      flutter build linux --release -v
-      cp -r build/linux/*/release/bundle/* $CRAFT_PART_INSTALL/bin/
+    build-packages: [libgtk-3-dev, ninja-build]
     stage-packages:
       - fonts-ubuntu
       - libgtk-3-0


### PR DESCRIPTION
Adds [`mir-flutter-app`](https://github.com/hbatagelo/mir_flutter_app.git) built from source into the snap. When the client is executed, it is kept alive for 120 seconds. This is enough for mir-ci to run the automated integration tests using the Robot framework.

NB: The reference application needs support for the mir_shell extension. This is currently not available in the mir_demo_server from the release ppa.